### PR TITLE
Add set-terminal-title function

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -228,6 +228,7 @@
 
    ;; Terminal utilities
    #:get-terminal-size
+   #:set-terminal-title
 
    ;; Conditions and error handling
    #:tuition-error

--- a/src/terminal.lisp
+++ b/src/terminal.lisp
@@ -141,6 +141,12 @@
   #-(or win32 unix)
   (cons 80 24)) ; default fallback
 
+(defun set-terminal-title (title)
+  "Set the terminal window title using OSC escape sequence.
+Works in most modern terminal emulators (xterm, gnome-terminal, iTerm2, etc.)."
+  (format t "~C]0;~A~C" #\Escape title (code-char 7))
+  (force-output))
+
 (defun clear-screen (&optional (stream *standard-output*))
   "Clear the terminal screen."
   (format stream "~C[2J~C[H" #\Escape #\Escape)


### PR DESCRIPTION
## Summary

- Adds `set-terminal-title` function to set the terminal window title
- Uses the standard OSC escape sequence: `ESC ] 0 ; <title> BEL`
- Exports the function from the tuition package

## Usage

```lisp
(tuition:set-terminal-title "My Application")
```

## Compatibility

Works in most modern terminal emulators:
- xterm
- gnome-terminal
- iTerm2
- Windows Terminal
- konsole
- Terminal.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)