### PR TITLE
fix: replace timed recvmsg with non-blocking getmsg + sleep in event loop

### DIFF
--- a/src/program.lisp
+++ b/src/program.lisp
@@ -227,17 +227,20 @@ Terminal modes are applied declaratively from the first view-state render."
     (close-tty-stream)))
 
 (defun event-loop (program)
-  "Main event processing loop with batched message processing."
+  "Main event processing loop with batched message processing.
+Uses non-blocking getmsg with sleep to avoid trivial-channels mutex
+issues with timed recvmsg on SBCL."
   (loop while (program-running program) do
     (handler-case
-        (let ((first-msg (trivial-channels:recvmsg (msg-channel program) 0.1)))
-          (when first-msg
-            (let ((messages (list first-msg)))
-              (loop for msg = (trivial-channels:getmsg (msg-channel program))
-                    while msg
-                    do (push msg messages))
-              (setf messages (nreverse messages))
-              (handle-messages-batch program messages))))
+        (let ((first-msg (trivial-channels:getmsg (msg-channel program))))
+          (if first-msg
+              (let ((messages (list first-msg)))
+                (loop for msg = (trivial-channels:getmsg (msg-channel program))
+                      while msg
+                      do (push msg messages))
+                (setf messages (nreverse messages))
+                (handle-messages-batch program messages))
+              (sleep 0.005)))
       (error (e)
         (handle-error :event-loop e)))))
 


### PR DESCRIPTION
## Summary

Fixes #12 — `exec-cmd` doesn't trigger immediate redraw after external program exits.

Replaces `trivial-channels:recvmsg` (blocking with 0.1s timeout) with non-blocking `trivial-channels:getmsg` + a 5ms sleep in the event loop. This eliminates a mutex race condition on SBCL that causes the event loop to miss queued messages after `exec-cmd` returns.

## Root Cause Analysis

The bug is a race condition that spans three libraries: **cl-tuition → trivial-channels → trivial-timeout**.

### The call chain

1. `event-loop` calls `(trivial-channels:recvmsg channel 0.1)` — block until a message arrives, or time out after 100ms
2. `recvmsg` wraps `bt:condition-wait` in `trivial-timeout:with-timeout` to implement the deadline:
   ```lisp
   ;; trivial-channels/trivial-channels.lisp, lines 73–90
   (defun wait-with-timeout (condition mutex seconds)
     (cond
       ((and seconds (> seconds 0))
        (handler-case
            (trivial-timeout:with-timeout (seconds)
              (bt:condition-wait condition mutex)
              t)
          (trivial-timeout:timeout-error (e)
            (declare (ignore e)))))
       ((null seconds)
        (bt:condition-wait condition mutex))))
   ```
3. On SBCL, `trivial-timeout:with-timeout` expands to `sb-ext:with-timeout`, which uses **asynchronous thread interruption** via a scheduled timer:
   ```lisp
   ;; trivial-timeout/dev/with-timeout.lisp, lines 31–37
   (handler-case 
       (sb-ext:with-timeout ,seconds-symbol (,doit-symbol))
     (sb-ext::timeout (c)
       (declare (ignore c))
       (error 'timeout-error)))
   ```

### Where it breaks

`bt:condition-wait` is a two-phase operation: it atomically releases the mutex and sleeps on the condition variable, then re-acquires the mutex when woken. When `sb-ext:with-timeout` fires, it interrupts the thread **asynchronously** — potentially at any point during this sequence:

- If the interrupt fires **between** the condition being signaled and the mutex being re-acquired, the `timeout-error` unwinds the stack while the mutex is in a transitional state
- Bordeaux Threads' cleanup semantics are not guaranteed under async interruption — the mutex can be left unreleased or in an inconsistent state
- On SBCL specifically, this manifests as spurious "Mutex not held" warnings

The practical effect on issue #12: after `run-exec-command` sends messages (a `window-size-msg` and the callback result) to the channel via `sendmsg`, the event loop's `recvmsg` call either:
1. Misses the notification because the condition variable was signaled during a bad window, or
2. Times out normally but the mutex state prevents the next iteration from seeing the queued messages

Either way, the messages sit in the channel until the next external event (a keypress) forces the loop forward.

### Why the root fix isn't in cl-tuition's scope

The proper fix would be for `trivial-channels:recvmsg` to use `bt:condition-wait`'s native `:timeout` parameter (available in Bordeaux Threads ≥ 0.9) instead of wrapping with `trivial-timeout`. However:

- `trivial-channels` hasn't been updated since 2016
- That fix belongs in `trivial-channels`, not here
- Even if `trivial-channels` were fixed, the current Quicklisp release would still carry the bug

## The Fix

Replace the blocking `recvmsg` with non-blocking `getmsg` + a short sleep:

```lisp
;; Before (broken on SBCL):
(let ((first-msg (trivial-channels:recvmsg (msg-channel program) 0.1)))
  (when first-msg
    ...))

;; After:
(let ((first-msg (trivial-channels:getmsg (msg-channel program))))
  (if first-msg
      (let ((messages (list first-msg)))
        (loop for msg = (trivial-channels:getmsg (msg-channel program))
              while msg
              do (push msg messages))
        (setf messages (nreverse messages))
        (handle-messages-batch program messages))
      (sleep 0.005)))
```

`getmsg` acquires the mutex, checks the queue, and releases immediately — no condition variable, no timeout, no async interruption. When the queue is empty, we sleep 5ms before polling again.

## Trade-offs

| | `recvmsg` (before) | `getmsg` + sleep (after) |
|---|---|---|
| **Idle behavior** | Blocks on condition variable; true sleep | Polls every 5ms; wakes briefly even when idle |
| **Message latency** | Up to 100ms worst case (timeout interval) | Up to 5ms worst case |
| **SBCL mutex safety** | Race condition via `trivial-timeout` | No condition variable involved; no race |
| **CPU when idle** | Near zero | Negligible (~200 wakes/sec, each a mutex lock + queue check) |
| **Exec-cmd redraw** | Broken — blank screen until keypress | Immediate — messages processed within 5ms |

For a TUI application, the 5ms polling overhead is negligible. The improvement in message latency and the elimination of the mutex race are significant wins.

## How I Found This

I encountered issue #12 while building [otenki](https://github.com/DarrenN/otenki), a weather TUI using cl-tuition. The blank screen after `exec-cmd` was reproducible on SBCL 2.5.x on macOS. Tracing through `trivial-channels` and `trivial-timeout` source revealed the async interruption issue. This polling approach has been running in production (my daily-use weather TUI) for several weeks without issue.

## Test Plan

- [x] `exec-cmd` redraws immediately after external program exits (the original issue #12 scenario)
- [x] Normal keyboard/mouse input processing unaffected
- [x] Window resize events processed correctly
- [x] No spurious SBCL mutex warnings in terminal output
- [x] Tested on SBCL 2.5.x, macOS (Darwin)