### PR TITLE
textarea: port recent bubbles features (scroll, word/edit, soft-wrap, dynamic height)

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,12 @@ Use components when you want common interactions without re‑implementing state
 ;; Text input
 (tuition.components.textinput:textinput-view
   (tuition.components.textinput:make-textinput :placeholder "Type here"))
+
+;; Textarea (multi-line; :soft-wrap and :dynamic-height are optional)
+(tuition.components.textarea:textarea-view
+  (tuition.components.textarea:make-textarea
+    :width 40 :height 6 :placeholder "Write a message..."
+    :soft-wrap t :dynamic-height t))
 ```
 
 ## Zones (mouse areas)

--- a/src/components/README.md
+++ b/src/components/README.md
@@ -91,6 +91,64 @@ Single-line text input field with cursor support.
 - `Backspace/Delete` - Delete characters
 - Any printable character - Insert
 
+### Textarea
+
+Multi-line text editor with cursor navigation, word editing, optional
+soft-wrapping, and an optional dynamic height.
+
+```lisp
+(use-package :tui.textarea)
+
+;; Create a textarea
+(defparameter *ta* (make-textarea
+                     :width 60 :height 10
+                     :placeholder "Type here..."
+                     :char-limit 280 :max-lines 1000
+                     :soft-wrap t :dynamic-height t))
+
+;; In your update - delegate key messages (only handled when focused)
+(defmethod tui:update ((model my-model) msg)
+  (multiple-value-bind (new-ta cmd)
+      (textarea-update (model-textarea model) msg)
+    (setf (model-textarea model) new-ta)
+    (values model cmd)))
+
+;; In your view
+(defmethod tui:view ((model my-model))
+  (textarea-view (model-textarea model)))
+
+;; Programmatic access
+(textarea-focus *ta*)                        ; focus (required to receive keys)
+(textarea-blur *ta*)
+(textarea-value *ta*)                        ; full contents
+(textarea-set-value *ta* "line 1
+line 2")
+(textarea-insert-string *ta* "more text")
+(textarea-cursor-position *ta*)              ; => (values row col)
+(textarea-line-count *ta*)
+```
+
+**Options:**
+- `:char-limit` / `:max-lines` — caps enforced on insert (0 / nil = unlimited)
+- `:soft-wrap t` — long lines wrap to `width` display columns; cursor and
+  scroll tracking move to visual lines
+- `:dynamic-height t` — viewport grows/shrinks to fit content, clamped to
+  `:min-height` / `:max-height`
+- `:show-line-numbers`, `:prompt`, `:placeholder`, `:width`, `:height`
+
+Soft-wrap and dynamic-height default off, so a plain textarea behaves exactly
+as before.
+
+**Keybindings:**
+- `←/→/↑/↓` - Move cursor
+- `Home`/`End` (or `Ctrl-a`/`Ctrl-e`) - Line start/end; `Ctrl-Home`/`Ctrl-End` - Document start/end
+- `Alt-b`/`Alt-f` - Move by word; `Alt-Backspace`/`Ctrl-w` and `Alt-d` - Delete by word
+- `Ctrl-t` - Transpose characters; `Alt-c`/`Alt-l`/`Alt-u` - Capitalize/lowercase/uppercase word
+- `Ctrl-k`/`Ctrl-u` - Delete to end/start of line
+- `PageUp`/`PageDown` - Page the viewport
+- `Backspace`/`Delete`/`Enter` - Delete and newline
+- `Ctrl-v` (or a bracketed paste) - Paste
+
 ### Progress Bar
 
 Visual progress indicator with customizable appearance.

--- a/src/components/textarea.lisp
+++ b/src/components/textarea.lisp
@@ -23,6 +23,12 @@
    #:textarea-show-line-numbers
    #:textarea-prompt
    #:textarea-char-limit
+   #:textarea-max-lines
+   #:textarea-yoffset
+   #:textarea-soft-wrap
+   #:textarea-dynamic-height
+   #:textarea-min-height
+   #:textarea-max-height
    #:textarea-line-numbers
 
    ;; Operations
@@ -36,10 +42,29 @@
    #:textarea-insert-rune
    #:textarea-set-value
 
+   ;; Scroll
+   #:textarea-scroll-position
+   #:textarea-scroll-percent
+   #:textarea-page-up
+   #:textarea-page-down
+   #:textarea-visual-line-count
+   #:textarea-recalculate-height
+
    ;; Cursor operations
    #:textarea-cursor-position
    #:textarea-line-count
-   #:textarea-length))
+   #:textarea-length
+   #:textarea-move-to-begin
+   #:textarea-move-to-end
+   #:textarea-cursor-word-backward
+   #:textarea-cursor-word-forward
+   #:textarea-delete-word-backward
+   #:textarea-delete-word-forward
+   #:textarea-word
+   #:textarea-transpose-chars
+   #:textarea-capitalize-word
+   #:textarea-lowercase-word
+   #:textarea-uppercase-word))
 
 (in-package #:tuition.components.textarea)
 
@@ -76,24 +101,50 @@
               :initform 1000
               :documentation "Maximum number of lines")
    (cursor-blink :initform t :accessor textarea-cursor-blink
-                 :documentation "Whether cursor is visible (for blinking)"))
+                 :documentation "Whether cursor is visible (for blinking)")
+   (yoffset :initform 0 :accessor textarea-yoffset
+            :documentation "Vertical scroll offset: index of the top visible line")
+   (soft-wrap :initarg :soft-wrap :accessor textarea-soft-wrap
+              :initform nil
+              :documentation "When true, long lines soft-wrap to WIDTH display columns (visual lines)")
+   (dynamic-height :initarg :dynamic-height :accessor textarea-dynamic-height
+                   :initform nil
+                   :documentation "When true, the viewport height grows/shrinks to fit the content")
+   (min-height :initarg :min-height :accessor textarea-min-height
+               :initform 1
+               :documentation "Minimum viewport height when DYNAMIC-HEIGHT is on")
+   (max-height :initarg :max-height :accessor textarea-max-height
+               :initform 0
+               :documentation "Maximum viewport height cap when DYNAMIC-HEIGHT is on (0 = no cap)"))
   (:documentation "A multi-line text input component."))
 
-(defun make-textarea (&key (width 40) (height 6) placeholder)
+(defun make-textarea (&key (width 40) (height 6) (placeholder "")
+                        (char-limit 0) (max-lines 1000)
+                        (show-line-numbers t) (prompt "> ")
+                        soft-wrap dynamic-height (min-height 1) (max-height 0))
   "Create a new textarea with the given dimensions."
-  (let ((ta (make-instance 'textarea :width width :height height)))
-    (when placeholder
-      (setf (textarea-placeholder ta) placeholder))
-    ta))
+  (make-instance 'textarea
+                 :width width :height height
+                 :char-limit char-limit :max-lines max-lines
+                 :show-line-numbers show-line-numbers :prompt prompt
+                 :placeholder placeholder
+                 :soft-wrap soft-wrap :dynamic-height dynamic-height
+                 :min-height min-height :max-height max-height))
 
 ;;; Content management
 
 (defun textarea-set-value (textarea text)
-  "Set the textarea's content."
-  (setf (textarea-lines textarea)
-        (coerce (tuition:split-string-by-newline text) 'vector))
+  "Set the textarea's content and reset cursor/scroll to the top."
+  (let* ((parts (tuition:split-string-by-newline text))
+         (parts (if (null parts) (list "") parts))
+         (n (length parts)))
+    ;; Build an adjustable vector with a fill pointer so that the
+    ;; merge/shrink paths (delete-char-backward/forward) can adjust-array it.
+    (setf (textarea-lines textarea)
+          (make-array n :initial-contents parts :adjustable t :fill-pointer n)))
   (setf (textarea-row textarea) 0
-        (textarea-col textarea) 0)
+        (textarea-col textarea) 0
+        (textarea-yoffset textarea) 0)
   textarea)
 
 (defun textarea-value (textarea)
@@ -104,64 +155,58 @@
         (format nil "~{~A~^~%~}" (coerce lines 'list)))))
 
 (defun textarea-insert-string (textarea str)
-  "Insert a string at the cursor position."
-  (let* ((lines (textarea-lines textarea))
-         (row (textarea-row textarea))
-         (col (textarea-col textarea))
-         (current-line (aref lines row))
-         (new-lines (tuition:split-string-by-newline str)))
-
-    (if (= (length new-lines) 1)
-        ;; Single line insert
-        (let ((new-line (concatenate 'string
-                                     (subseq current-line 0 col)
-                                     (first new-lines)
-                                     (subseq current-line col))))
-          (setf (aref lines row) new-line)
-          (setf (textarea-col textarea)
-                (+ col (length (first new-lines)))))
-
-        ;; Multi-line insert
-        (let* ((first-part (concatenate 'string
-                                        (subseq current-line 0 col)
-                                        (first new-lines)))
-               (last-part (concatenate 'string
-                                       (car (last new-lines))
-                                       (subseq current-line col)))
-               (middle-parts (subseq new-lines 1 (1- (length new-lines))))
-               (total-new-lines (1- (length new-lines))))
-
-          ;; Update the current line with the first part
-          (setf (aref lines row) first-part)
-
-          ;; Insert new lines
-          (let ((new-vector (make-array (+ (length lines) total-new-lines)
-                                        :fill-pointer (+ (length lines) total-new-lines)
-                                        :adjustable t)))
-            ;; Copy lines before insertion point
-            (loop for i from 0 below row
-                  do (setf (aref new-vector i) (aref lines i)))
-
-            ;; Add first line (already set above)
-            (setf (aref new-vector row) first-part)
-
-            ;; Add middle lines
-            (loop for line in middle-parts
-                  for i from (1+ row)
-                  do (setf (aref new-vector i) line))
-
-            ;; Add last line
-            (setf (aref new-vector (+ row total-new-lines)) last-part)
-
-            ;; Copy remaining lines
-            (loop for i from (1+ row) below (length lines)
-                  do (setf (aref new-vector (+ i total-new-lines))
-                          (aref lines i)))
-
-            (setf (textarea-lines textarea) new-vector)
-            (setf (textarea-row textarea) (+ row total-new-lines))
-            (setf (textarea-col textarea) (length (car (last new-lines)))))))
-    textarea))
+  "Insert a string at the cursor position, respecting char-limit and max-lines."
+  (let ((insert (%ta-fit-to-limits textarea str)))
+    (when (string= insert "")
+      (return-from textarea-insert-string textarea))
+    (let* ((lines (textarea-lines textarea))
+           (row (textarea-row textarea))
+           (col (textarea-col textarea))
+           (current-line (aref lines row))
+           (new-lines (tuition:split-string-by-newline insert)))
+      (if (= (length new-lines) 1)
+          ;; Single line insert
+          (let ((new-line (concatenate 'string
+                                       (subseq current-line 0 col)
+                                       (first new-lines)
+                                       (subseq current-line col))))
+            (setf (aref lines row) new-line)
+            (setf (textarea-col textarea)
+                  (+ col (length (first new-lines)))))
+          ;; Multi-line insert
+          (let* ((first-part (concatenate 'string
+                                          (subseq current-line 0 col)
+                                          (first new-lines)))
+                 (last-part (concatenate 'string
+                                         (car (last new-lines))
+                                         (subseq current-line col)))
+                 (middle-parts (subseq new-lines 1 (1- (length new-lines))))
+                 (total-new-lines (1- (length new-lines))))
+            ;; Update the current line with the first part
+            (setf (aref lines row) first-part)
+            ;; Insert new lines
+            (let ((new-vector (make-array (+ (length lines) total-new-lines)
+                                          :fill-pointer (+ (length lines) total-new-lines)
+                                          :adjustable t)))
+              ;; Copy lines before insertion point
+              (loop for i from 0 below row
+                    do (setf (aref new-vector i) (aref lines i)))
+              ;; Add first line (already set above)
+              (setf (aref new-vector row) first-part)
+              ;; Add middle lines
+              (loop for line in middle-parts
+                    for i from (1+ row)
+                    do (setf (aref new-vector i) line))
+              ;; Add last line
+              (setf (aref new-vector (+ row total-new-lines)) last-part)
+              ;; Copy remaining lines
+              (loop for i from (1+ row) below (length lines)
+                    do (setf (aref new-vector (+ i total-new-lines))
+                             (aref lines i)))
+              (setf (textarea-lines textarea) new-vector)
+              (setf (textarea-row textarea) (+ row total-new-lines))
+              (setf (textarea-col textarea) (length (car (last new-lines)))))))
+      textarea)))
 
 (defun textarea-insert-rune (textarea char)
   "Insert a single character at the cursor position."
@@ -185,7 +230,8 @@
   "Reset the textarea to empty state."
   (setf (textarea-lines textarea) (vector "")
         (textarea-row textarea) 0
-        (textarea-col textarea) 0)
+        (textarea-col textarea) 0
+        (textarea-yoffset textarea) 0)
   textarea)
 
 (defun textarea-focus (textarea)
@@ -320,7 +366,11 @@
   textarea)
 
 (defun textarea-newline (textarea)
-  "Insert a newline at cursor position."
+  "Insert a newline at cursor position, respecting max-lines."
+  (let ((max-lines (textarea-max-lines textarea)))
+    (when (and (plusp max-lines)
+               (>= (textarea-line-count textarea) max-lines))
+      (return-from textarea-newline textarea)))
   (let* ((lines (textarea-lines textarea))
          (row (textarea-row textarea))
          (col (textarea-col textarea))
@@ -349,6 +399,340 @@
             (textarea-col textarea) 0)))
   textarea)
 
+;;; Word helpers.  A "word char" is alphanumeric, matching textinput's
+;;; %ti-prev/next-word-boundary convention so both inputs behave the same.
+
+(defun %ta-word-char-p (ch)
+  "Non-nil if CH is part of a word (alphanumeric)."
+  (alphanumericp ch))
+
+(defun %ta-prev-word-boundary (s pos)
+  "Return the index of the start of the word at or before POS in S.
+Whitespace is skipped, so repeated calls walk backwards word by word."
+  (let ((i (min (max 0 pos) (length s))))
+    ;; Skip non-word chars to the left.
+    (loop while (and (> i 0) (not (%ta-word-char-p (char s (1- i)))))
+          do (decf i))
+    ;; Skip word chars to the left.
+    (loop while (and (> i 0) (%ta-word-char-p (char s (1- i))))
+          do (decf i))
+    i))
+
+(defun %ta-next-word-boundary (s pos)
+  "Return the index of the start of the next word after POS in S, or the end.
+If POS is inside a word, first moves past that word, then skips whitespace."
+  (let ((i (min (max 0 pos) (length s))) (n (length s)))
+    ;; Skip the current word.
+    (loop while (and (< i n) (%ta-word-char-p (char s i))) do (incf i))
+    ;; Skip following whitespace.
+    (loop while (and (< i n) (not (%ta-word-char-p (char s i)))) do (incf i))
+    i))
+
+(defun %ta-word-at (line col)
+  "Return the alphanumeric word containing position COL in LINE, or empty."
+  (cond
+    ((or (minusp col) (>= col (length line))) "")
+    ((not (%ta-word-char-p (char line col))) "")
+    (t (let ((start col) (end col))
+         (loop while (and (> start 0) (%ta-word-char-p (char line (1- start))))
+               do (decf start))
+         (loop while (and (< end (length line)) (%ta-word-char-p (char line end)))
+               do (incf end))
+         (subseq line start end)))))
+
+(defun textarea-word (textarea)
+  "Return the word under the cursor: the run of word-chars touching the
+character immediately left of the cursor.  Empty when not on a word."
+  (let* ((lines (textarea-lines textarea))
+         (row (textarea-row textarea))
+         (line (if (< row (length lines)) (aref lines row) "")))
+    (%ta-word-at line (1- (textarea-col textarea)))))
+
+(defun textarea-cursor-word-backward (textarea)
+  "Move the cursor to the start of the previous word."
+  (let ((b (%ta-prev-word-boundary (textarea-current-line textarea)
+                                   (textarea-col textarea))))
+    (when b (setf (textarea-col textarea) b)))
+  textarea)
+
+(defun textarea-cursor-word-forward (textarea)
+  "Move the cursor past the current word, or to the end of the line."
+  (let ((f (%ta-next-word-boundary (textarea-current-line textarea)
+                                   (textarea-col textarea))))
+    (when f (setf (textarea-col textarea) f)))
+  textarea)
+
+(defun textarea-delete-word-backward (textarea)
+  "Delete the word before the cursor."
+  (let* ((lines (textarea-lines textarea))
+         (row (textarea-row textarea))
+         (line (aref lines row))
+         (col (textarea-col textarea))
+         (b (%ta-prev-word-boundary line col)))
+    (when (and b (< b col))
+      (setf (aref lines row)
+            (concatenate 'string (subseq line 0 b) (subseq line col)))
+      (setf (textarea-col textarea) b)))
+  textarea)
+
+(defun textarea-delete-word-forward (textarea)
+  "Delete the word after the cursor."
+  (let* ((lines (textarea-lines textarea))
+         (row (textarea-row textarea))
+         (line (aref lines row))
+         (col (textarea-col textarea))
+         (f (%ta-next-word-boundary line col)))
+    (when (and f (> f col))
+      (setf (aref lines row)
+            (concatenate 'string (subseq line 0 col) (subseq line f)))))
+  textarea)
+
+;;; Character transpose and word-case commands (readline niceties)
+
+(defun textarea-transpose-chars (textarea)
+  "Transpose the characters around the cursor (readline Ctrl-T).
+At end of line, swaps the last two characters; at the start, does nothing."
+  (let* ((lines (textarea-lines textarea))
+         (row (textarea-row textarea))
+         (col (textarea-col textarea))
+         (line (aref lines row))
+         (len (length line)))
+    (cond
+      ((< len 2) textarea)                        ; nothing to swap
+      ((>= col len)                               ; cursor at/past end
+       (setf (aref lines row)
+             (concatenate 'string
+                           (subseq line 0 (- len 2))
+                           (string (char line (1- len)))
+                           (string (char line (- len 2)))))
+       textarea)
+      ((> col 0)                                  ; cursor mid-line
+       (setf (aref lines row)
+             (concatenate 'string
+                           (subseq line 0 (1- col))
+                           (string (char line col))
+                           (string (char line (1- col)))
+                           (subseq line (1+ col))))
+       (incf (textarea-col textarea))
+       textarea)
+      (t textarea))))                             ; col 0: nothing before cursor
+
+(defun %ta-skip-to-word (line col)
+  "Return the index of the first word char at or after COL in LINE."
+  (let ((i col) (n (length line)))
+    (loop while (and (< i n) (not (%ta-word-char-p (char line i)))) do (incf i))
+    i))
+
+(defun %ta-word-end-after (line start)
+  "Return the index just past the word that begins at START."
+  (let ((i start) (n (length line)))
+    (loop while (and (< i n) (%ta-word-char-p (char line i))) do (incf i))
+    i))
+
+(defun %ta-capitalize-string (s)
+  "Upcase the first character of S and downcase the rest."
+  (if (plusp (length s))
+      (concatenate 'string
+                   (string (char-upcase (char s 0)))
+                   (string-downcase (subseq s 1)))
+      s))
+
+(defun %ta-case-word (textarea fn)
+  "Apply FN (string->string) to the word at/after the cursor, then move past it."
+  (let* ((lines (textarea-lines textarea))
+         (row (textarea-row textarea))
+         (line (aref lines row))
+         (start (%ta-skip-to-word line (textarea-col textarea))))
+    (when (< start (length line))
+      (let* ((end (%ta-word-end-after line start))
+             (cased (funcall fn (subseq line start end))))
+        (setf (aref lines row)
+              (concatenate 'string (subseq line 0 start) cased (subseq line end)))
+        (setf (textarea-col textarea) end))))
+  textarea)
+
+(defun textarea-capitalize-word (textarea)
+  "Capitalize the word at/after the cursor (Alt+c)."
+  (%ta-case-word textarea #'%ta-capitalize-string))
+
+(defun textarea-lowercase-word (textarea)
+  "Lowercase the word at/after the cursor (Alt+l)."
+  (%ta-case-word textarea #'string-downcase))
+
+(defun textarea-uppercase-word (textarea)
+  "Uppercase the word at/after the cursor (Alt+u)."
+  (%ta-case-word textarea #'string-upcase))
+
+;;; Document-level cursor movement
+
+(defun textarea-move-to-begin (textarea)
+  "Move the cursor to the very beginning of the text."
+  (setf (textarea-row textarea) 0
+        (textarea-col textarea) 0)
+  textarea)
+
+(defun textarea-move-to-end (textarea)
+  "Move the cursor to the very end of the text."
+  (let ((last (1- (textarea-line-count textarea))))
+    (setf (textarea-row textarea) (max 0 last))
+    (setf (textarea-col textarea)
+          (length (textarea-current-line textarea))))
+  textarea)
+
+;;; Soft-wrapping: mapping logical lines to visual (wrapped) lines.
+;;; When SOFT-WRAP is on, the viewport, scroll offset, and cursor-in-view
+;;; tracking all operate in visual lines (a logical line wider than WIDTH
+;;; occupies several visual lines).
+
+(defun %ta-wrap-line (line width)
+  "Split LINE into char-offset segments, each no wider than WIDTH display
+columns (greedy, character wrapping).  Returns a list of (start . end) conses."
+  (let ((n (length line)))
+    (cond
+      ((<= width 0) (list (cons 0 n)))            ; no wrapping: whole line
+      ((zerop n) (list (cons 0 0)))               ; empty line: one empty segment
+      (t (let ((segments '()) (start 0))
+           (loop while (< start n) do
+             (let ((end start))
+               (loop while (< end n) do
+                 (if (> (tuition:visible-length (subseq line start (1+ end))) width)
+                     (loop-finish)
+                     (incf end)))
+               ;; Force at least one character per segment so a single wide
+               ;; character (wider than WIDTH) still makes progress.
+               (when (= end start) (incf end))
+               (push (cons start end) segments)
+               (setf start end)))
+           (nreverse segments))))))
+
+(defun %ta-visual-lines (textarea)
+  "Return a vector of visual lines, each a list (LOGICAL-ROW START END)."
+  (let ((lines (textarea-lines textarea))
+        (width (max 1 (textarea-width textarea)))
+        (result '()))
+    (loop for row from 0 below (length lines) do
+      (dolist (seg (%ta-wrap-line (aref lines row) width))
+        (push (list row (car seg) (cdr seg)) result)))
+    (coerce (nreverse result) 'vector)))
+
+(defun %ta-cursor-visual-index (textarea visuals)
+  "Index into VISUALS of the segment containing the cursor (row, col)."
+  (let ((row (textarea-row textarea))
+        (col (textarea-col textarea)))
+    (or (position-if (lambda (v)
+                       (and (= (first v) row)
+                            (<= (second v) col (third v))))
+                     visuals)
+        0)))
+
+(defun textarea-visual-line-count (textarea)
+  "Number of visual (wrapped) lines.  Equals the logical line count when
+SOFT-WRAP is off."
+  (if (textarea-soft-wrap textarea)
+      (length (%ta-visual-lines textarea))
+      (textarea-line-count textarea)))
+
+;;; Paging and vertical scroll offset (keep the cursor in view)
+
+(defun textarea-page-up (textarea)
+  "Move the cursor up by roughly one viewport height."
+  (let ((delta (max 1 (textarea-height textarea))))
+    (setf (textarea-row textarea)
+          (max 0 (- (textarea-row textarea) delta)))
+    (textarea-set-cursor textarea (textarea-col textarea)))
+  textarea)
+
+(defun textarea-page-down (textarea)
+  "Move the cursor down by roughly one viewport height."
+  (let ((delta (max 1 (textarea-height textarea)))
+        (last (1- (textarea-line-count textarea))))
+    (setf (textarea-row textarea)
+          (min (max 0 last) (+ (textarea-row textarea) delta)))
+    (textarea-set-cursor textarea (textarea-col textarea)))
+  textarea)
+
+(defun textarea-recalculate-height (textarea)
+  "When DYNAMIC-HEIGHT is on, fit the viewport height to the visual content,
+clamped between MIN-HEIGHT and MAX-HEIGHT.  No-op otherwise."
+  (when (textarea-dynamic-height textarea)
+    (let* ((total (textarea-visual-line-count textarea))
+           (h (max total (max 1 (textarea-min-height textarea))))
+           (cap (textarea-max-height textarea)))
+      (when (plusp cap) (setf h (min h cap)))
+      (setf (textarea-height textarea) h)))
+  textarea)
+
+(defun textarea-ensure-visible (textarea)
+  "Adjust the scroll offset so the cursor stays within the viewport.
+In soft-wrap mode the cursor is tracked in visual (wrapped) lines; otherwise in
+logical rows.  Also called from TEXTAREA-VIEW so the cursor can never scroll
+out of sight regardless of how state was mutated."
+  (let ((h (max 1 (textarea-height textarea)))
+        (yoff (textarea-yoffset textarea)))
+    (let ((cur (if (textarea-soft-wrap textarea)
+                   (%ta-cursor-visual-index textarea (%ta-visual-lines textarea))
+                   (textarea-row textarea))))
+      (cond
+        ((< cur yoff) (setf (textarea-yoffset textarea) cur))
+        ((>= cur (+ yoff h))
+         (setf (textarea-yoffset textarea) (1+ (- cur h)))))))
+  textarea)
+
+(defun textarea-clamp-yoffset (textarea)
+  "Keep the scroll offset within [0, visual-line-count - height]."
+  (let* ((total (textarea-visual-line-count textarea))
+         (h (max 1 (textarea-height textarea)))
+         (max-off (max 0 (- total h))))
+    (when (< (textarea-yoffset textarea) 0)
+      (setf (textarea-yoffset textarea) 0))
+    (when (> (textarea-yoffset textarea) max-off)
+      (setf (textarea-yoffset textarea) max-off)))
+  textarea)
+
+(defun textarea-scroll-position (textarea)
+  "Return the index of the top visible line (the scroll offset)."
+  (textarea-yoffset textarea))
+
+(defun textarea-scroll-percent (textarea)
+  "Return scroll progress through the content as a float in [0.0, 1.0]."
+  (let ((n (textarea-visual-line-count textarea))
+        (h (max 1 (textarea-height textarea))))
+    (if (or (<= n 1) (<= n h))
+        0.0
+        (/ (float (textarea-yoffset textarea))
+           (float (- n h))))))
+
+;;; Input limits: char-limit (total runes) and max-lines
+
+(defun %ta-truncate-to-newlines (str max-newlines)
+  "Return STR cut so it contains at most MAX-NEWLINES #\\Newline characters."
+  (let ((count 0))
+    (loop for ch across str
+          for idx from 0
+          when (char= ch #\Newline)
+            do (progn
+                 (incf count)
+                 (when (> count max-newlines)
+                   (return-from %ta-truncate-to-newlines
+                     (subseq str 0 idx))))))
+  str)
+
+(defun %ta-fit-to-limits (textarea str)
+  "Trim STR so an insert respects char-limit (total runes) and max-lines."
+  (let ((s str))
+    ;; Character limit counts runes across all lines (see TEXTAREA-LENGTH).
+    (let ((limit (textarea-char-limit textarea)))
+      (when (plusp limit)
+        (let ((avail (max 0 (- limit (textarea-length textarea)))))
+          (when (> (length s) avail)
+            (setf s (subseq s 0 avail))))))
+    ;; Line limit: never create more than MAX-LINES lines.
+    (let ((max-lines (textarea-max-lines textarea)))
+      (when (plusp max-lines)
+        (let ((allowed (max 0 (- max-lines (textarea-line-count textarea)))))
+          (setf s (%ta-truncate-to-newlines s allowed)))))
+    s))
+
 ;;; TEA protocol implementation
 
 (defun textarea-init (textarea)
@@ -360,73 +744,121 @@
   "Update textarea with a message. Returns (values new-textarea cmd)."
   (unless (textarea-focused textarea)
     (return-from textarea-update (values textarea nil)))
+  (multiple-value-bind (_ cmd) (%textarea-dispatch-key textarea msg)
+    (declare (ignore _))
+    ;; Grow/shrink the viewport to fit content (when dynamic-height), then
+    ;; keep the cursor inside the viewport and the offset within bounds.
+    (textarea-recalculate-height textarea)
+    (textarea-ensure-visible textarea)
+    (textarea-clamp-yoffset textarea)
+    (values textarea cmd)))
 
-  (cond
-    ;; Key messages
-    ((tuition:key-press-msg-p msg)
-     (let ((key (tuition:key-event-code msg))
-           (ctrl (tuition:mod-contains (tuition:key-event-mod msg) tuition:+mod-ctrl+)))
-       (cond
-         ;; Navigation
-         ((eq key :up)
-          (values (textarea-cursor-up textarea) nil))
-         ((eq key :down)
-          (values (textarea-cursor-down textarea) nil))
-         ((eq key :left)
-          (values (textarea-cursor-left textarea) nil))
-         ((eq key :right)
-          (values (textarea-cursor-right textarea) nil))
+(defun %textarea-dispatch-key (textarea msg)
+  "Handle one message, returning (values textarea cmd).  Mutates TEXTAREA in
+place.  Only called when the textarea is focused."
+  ;; Bracketed paste.
+  (when (typep msg 'tuition:paste-msg)
+    (textarea-insert-string textarea (tuition:paste-msg-text msg))
+    (return-from %textarea-dispatch-key (values textarea nil)))
+  (unless (tuition:key-press-msg-p msg)
+    (return-from %textarea-dispatch-key (values textarea nil)))
+  (let ((key (tuition:key-event-code msg))
+        (alt (tuition:mod-contains (tuition:key-event-mod msg) tuition:+mod-alt+))
+        (ctrl (tuition:mod-contains (tuition:key-event-mod msg) tuition:+mod-ctrl+)))
+    (cond
+      ;; Arrow navigation
+      ((eq key :up)    (values (textarea-cursor-up textarea) nil))
+      ((eq key :down)  (values (textarea-cursor-down textarea) nil))
+      ((eq key :left)  (values (textarea-cursor-left textarea) nil))
+      ((eq key :right) (values (textarea-cursor-right textarea) nil))
 
-         ;; Home/End
-         ((or (eq key :home) (and ctrl (characterp key) (char= key #\a)))
-          (values (textarea-cursor-start textarea) nil))
-         ((or (eq key :end) (and ctrl (characterp key) (char= key #\e)))
-          (values (textarea-cursor-end textarea) nil))
+      ;; Paging
+      ((eq key :page-up)   (values (textarea-page-up textarea) nil))
+      ((eq key :page-down) (values (textarea-page-down textarea) nil))
 
-         ;; Deletion
-         ((eq key :backspace)
-          (values (textarea-delete-char-backward textarea) nil))
-         ((eq key :delete)
-          (values (textarea-delete-char-forward textarea) nil))
+      ;; Document-level begin/end (must precede line start/end below)
+      ((and ctrl (eq key :home)) (values (textarea-move-to-begin textarea) nil))
+      ((and ctrl (eq key :end))  (values (textarea-move-to-end textarea) nil))
 
-         ;; Newline
-         ((or (eq key :enter) (and ctrl (characterp key) (char= key #\m)))
-          (values (textarea-newline textarea) nil))
+      ;; Word movement (Alt+b / Alt+f)
+      ((and alt (characterp key) (char= key #\b))
+       (values (textarea-cursor-word-backward textarea) nil))
+      ((and alt (characterp key) (char= key #\f))
+       (values (textarea-cursor-word-forward textarea) nil))
 
-         ;; Delete to end of line (Ctrl+K)
-         ((and ctrl (characterp key) (char= key #\k))
-          (let* ((lines (textarea-lines textarea))
-                 (row (textarea-row textarea))
-                 (col (textarea-col textarea))
-                 (line (aref lines row)))
-            (setf (aref lines row) (subseq line 0 col))
-            (values textarea nil)))
+      ;; Word deletion (Ctrl+w, Alt+Backspace, Alt+d)
+      ((and ctrl (characterp key) (char= key #\w))
+       (values (textarea-delete-word-backward textarea) nil))
+      ((and alt (eq key :backspace))
+       (values (textarea-delete-word-backward textarea) nil))
+      ((and alt (characterp key) (char= key #\d))
+       (values (textarea-delete-word-forward textarea) nil))
 
-         ;; Delete to start of line (Ctrl+U)
-         ((and ctrl (characterp key) (char= key #\u))
-          (let* ((lines (textarea-lines textarea))
-                 (row (textarea-row textarea))
-                 (col (textarea-col textarea))
-                 (line (aref lines row)))
-            (setf (aref lines row) (subseq line col))
-            (setf (textarea-col textarea) 0)
-            (values textarea nil)))
+      ;; Transpose (Ctrl+t) and word case (Alt+c / Alt+l / Alt+u)
+      ((and ctrl (characterp key) (char= key #\t))
+       (values (textarea-transpose-chars textarea) nil))
+      ((and alt (characterp key) (char= key #\c))
+       (values (textarea-capitalize-word textarea) nil))
+      ((and alt (characterp key) (char= key #\l))
+       (values (textarea-lowercase-word textarea) nil))
+      ((and alt (characterp key) (char= key #\u))
+       (values (textarea-uppercase-word textarea) nil))
 
-         ;; Regular character input
-         ((characterp key)
-          (let ((char-str (string key)))
-            (values (textarea-insert-string textarea char-str) nil)))
+      ;; Line start / end (Home, Ctrl+a / End, Ctrl+e)
+      ((or (eq key :home) (and ctrl (characterp key) (char= key #\a)))
+       (values (textarea-cursor-start textarea) nil))
+      ((or (eq key :end) (and ctrl (characterp key) (char= key #\e)))
+       (values (textarea-cursor-end textarea) nil))
 
-         ;; No match
-         (t (values textarea nil)))))
+      ;; Character deletion
+      ((eq key :backspace) (values (textarea-delete-char-backward textarea) nil))
+      ((eq key :delete)    (values (textarea-delete-char-forward textarea) nil))
 
-    ;; Default: no change
-    (t (values textarea nil))))
+      ;; Newline
+      ((or (eq key :enter) (and ctrl (characterp key) (char= key #\m)))
+       (values (textarea-newline textarea) nil))
+
+      ;; Delete to end of line (Ctrl+K)
+      ((and ctrl (characterp key) (char= key #\k))
+       (let* ((lines (textarea-lines textarea))
+              (row (textarea-row textarea))
+              (col (textarea-col textarea))
+              (line (aref lines row)))
+         (setf (aref lines row) (subseq line 0 col))
+         (values textarea nil)))
+
+      ;; Delete to start of line (Ctrl+U)
+      ((and ctrl (characterp key) (char= key #\u))
+       (let* ((lines (textarea-lines textarea))
+              (row (textarea-row textarea))
+              (col (textarea-col textarea))
+              (line (aref lines row)))
+         (setf (aref lines row) (subseq line col))
+         (setf (textarea-col textarea) 0)
+         (values textarea nil)))
+
+      ;; Regular character input
+      ((characterp key)
+       (values (textarea-insert-string textarea (string key)) nil))
+
+      ;; No match
+      (t (values textarea nil)))))
 
 (defun textarea-view (textarea)
   "Render the textarea to a string."
+  (textarea-recalculate-height textarea)
+  (textarea-ensure-visible textarea)
+  (textarea-clamp-yoffset textarea)
+  (if (textarea-soft-wrap textarea)
+      (%ta-view-wrapped textarea)
+      (%ta-view-logical textarea)))
+
+(defun %ta-view-logical (textarea)
+  "Render one logical line per visual line (no soft-wrapping)."
   (let* ((lines (textarea-lines textarea))
+         (n (length lines))
          (height (textarea-height textarea))
+         (yoff (textarea-yoffset textarea))
          (show-ln (textarea-show-line-numbers textarea))
          (prompt (textarea-prompt textarea))
          (row (textarea-row textarea))
@@ -448,13 +880,12 @@
                      (if show-ln (format nil "~vA " ln-width "1") "")
                      placeholder)
               result)
-        (return-from textarea-view (format nil "~{~A~^~%~}" (nreverse result))))
+        (return-from %ta-view-logical (format nil "~{~A~^~%~}" (nreverse result))))
 
-      ;; Render visible lines
+      ;; Render visible lines, starting at the scroll offset.
       (dotimes (i height)
-        (let ((line-text (if (< i (length lines))
-                            (aref lines i)
-                            "")))
+        (let* ((line-no (+ yoff i))
+               (line-text (if (< line-no n) (aref lines line-no) "")))
 
           ;; Build line
           (with-output-to-string (s)
@@ -463,12 +894,12 @@
 
             ;; Line number
             (when show-ln
-              (if (< i (length lines))
-                  (format s "~v@A " ln-width (1+ i))
+              (if (< line-no n)
+                  (format s "~v@A " ln-width (1+ line-no))
                   (format s "~vA " ln-width "")))
 
             ;; Content with cursor
-            (if (and focused (= i row) (< i (length lines)))
+            (if (and focused (= line-no row) (< line-no n))
                 ;; Line with cursor
                 (let ((before (subseq line-text 0 (min col (length line-text))))
                       (at-cursor (if (< col (length line-text))
@@ -482,5 +913,71 @@
                 (format s "~A" line-text))
 
             (push (get-output-stream-string s) result)))))
+
+    (format nil "~{~A~^~%~}" (nreverse result))))
+
+(defun %ta-view-wrapped (textarea)
+  "Render with each logical line soft-wrapped to WIDTH display columns."
+  (let* ((lines (textarea-lines textarea))
+         (height (textarea-height textarea))
+         (yoff (textarea-yoffset textarea))
+         (show-ln (textarea-show-line-numbers textarea))
+         (prompt (textarea-prompt textarea))
+         (col (textarea-col textarea))
+         (focused (textarea-focused textarea))
+         (placeholder (textarea-placeholder textarea))
+         (ln-width (if show-ln
+                       (+ 2 (length (write-to-string (textarea-line-count textarea))))
+                       0))
+         (visuals (%ta-visual-lines textarea))
+         (cursor-vi (%ta-cursor-visual-index textarea visuals))
+         (result '()))
+
+    ;; If empty and has placeholder
+    (when (and (string= (textarea-value textarea) "")
+               (not (string= placeholder "")))
+      (push (format nil "~A~A~A"
+                   prompt
+                   (if show-ln (format nil "~vA " ln-width "1") "")
+                   placeholder)
+            result)
+      (return-from %ta-view-wrapped (format nil "~{~A~^~%~}" (nreverse result))))
+
+    ;; Render visible (wrapped) lines, starting at the scroll offset.
+    (dotimes (i height)
+      (let ((vi (+ yoff i)))
+        (push
+         (cond
+           ((>= vi (length visuals))
+            ;; Blank line beyond content.
+            (with-output-to-string (s)
+              (format s "~A" prompt)
+              (when show-ln (format s "~vA " ln-width ""))))
+           (t
+            (let* ((v (aref visuals vi))
+                   (lrow (first v)) (vstart (second v)) (vend (third v))
+                   (line (aref lines lrow))
+                   (seg (subseq line vstart vend))
+                   (seg-len (- vend vstart))
+                   (first-seg-p (zerop vstart)))
+              (with-output-to-string (s)
+                (format s "~A" prompt)
+                (when show-ln
+                  (if first-seg-p
+                      (format s "~v@A " ln-width (1+ lrow))
+                      (format s "~vA " ln-width "")))
+                (if (and focused (= vi cursor-vi))
+                    ;; Cursor sits within this segment.
+                    (let* ((local-col (- col vstart))
+                           (before (subseq seg 0 (min local-col seg-len)))
+                           (at-cursor (if (< local-col seg-len)
+                                          (string (char seg local-col))
+                                          " "))
+                           (after (if (< local-col seg-len)
+                                      (subseq seg (min (1+ local-col) seg-len))
+                                      "")))
+                      (format s "~A[~A]~A" before at-cursor after))
+                    (format s "~A" seg))))))
+         result)))
 
     (format nil "~{~A~^~%~}" (nreverse result))))

--- a/tests/test-textarea.lisp
+++ b/tests/test-textarea.lisp
@@ -1,0 +1,419 @@
+;;; test-textarea.lisp
+;;;
+;;; SPDX-License-Identifier: MIT
+;;;
+;;; Copyright (C) 2025  Anthony Green <green@moxielogic.com>
+;;;
+;;;; Tests for the textarea component (src/components/textarea.lisp)
+
+(in-package #:tuition-tests)
+
+(def-suite textarea-tests
+  :description "Tests for the textarea component."
+  :in tuition-tests)
+
+(in-suite textarea-tests)
+
+;;; --- test helpers ---
+
+(defun ta-make (value &rest make-args)
+  "Make a textarea, set VALUE, leaving the cursor at (0,0)."
+  (let ((ta (apply #'tui.textarea:make-textarea make-args)))
+    (tui.textarea:textarea-set-value ta value)
+    ta))
+
+(defun ta-cursor (ta)
+  "Return the cursor position as a list (row col)."
+  (multiple-value-list (tui.textarea:textarea-cursor-position ta)))
+
+(defun ta-set-cursor (ta row col)
+  "Force the cursor to ROW, COL."
+  (setf (tui.textarea::textarea-row ta) row
+        (tui.textarea::textarea-col ta) col)
+  ta)
+
+(defun ta-key (ta code &optional mod)
+  "Feed a key-press message to TA (focused).  Returns TA."
+  (tui.textarea:textarea-update ta
+                                (make-key-press-msg :code code :mod (or mod 0)))
+  ta)
+
+;;; --- document-level movement (#809) ---
+
+(test textarea-move-to-end
+  "Move-to-end lands on the last row, past its last character."
+  (let ((ta (ta-make (format nil "aaa~%bbb~%ccc"))))
+    (tui.textarea:textarea-move-to-end ta)
+    (is (equal '(2 3) (ta-cursor ta)))))
+
+(test textarea-move-to-begin
+  "Move-to-begin lands on (0,0) even from the end."
+  (let ((ta (ta-make (format nil "aaa~%bbb~%ccc"))))
+    (tui.textarea:textarea-move-to-end ta)
+    (tui.textarea:textarea-move-to-begin ta)
+    (is (equal '(0 0) (ta-cursor ta)))))
+
+;;; --- word under cursor (#814) ---
+
+(test textarea-word-finds-word
+  "Word() returns the word under the cursor."
+  (let ((ta (ta-make "hello world")))
+    (ta-set-cursor ta 0 1)
+    (is (string= "hello" (tui.textarea:textarea-word ta)))
+    (ta-set-cursor ta 0 7)
+    (is (string= "world" (tui.textarea:textarea-word ta)))))
+
+(test textarea-word-empty-when-not-on-word
+  "Word() is empty on whitespace or at the very start."
+  (let ((ta (ta-make "hello world")))
+    (ta-set-cursor ta 0 6)                       ; on the space
+    (is (string= "" (tui.textarea:textarea-word ta)))
+    (ta-set-cursor ta 0 0)                       ; before the first char
+    (is (string= "" (tui.textarea:textarea-word ta)))))
+
+;;; --- word navigation ---
+
+(test textarea-word-forward-walks
+  "Alt-f walks forward word by word, skipping whitespace."
+  (let ((ta (ta-make "alpha beta gamma")))
+    (ta-set-cursor ta 0 0)
+    (tui.textarea:textarea-cursor-word-forward ta)
+    (is (equal '(0 6) (ta-cursor ta)))           ; start of "beta"
+    (tui.textarea:textarea-cursor-word-forward ta)
+    (is (equal '(0 11) (ta-cursor ta)))          ; start of "gamma"
+    (tui.textarea:textarea-cursor-word-forward ta)
+    (is (equal '(0 16) (ta-cursor ta)))))        ; end of line
+
+(test textarea-word-backward-walks
+  "Alt-b walks backward word by word, skipping whitespace."
+  (let ((ta (ta-make "alpha beta gamma")))
+    (ta-set-cursor ta 0 16)                       ; end of line
+    (tui.textarea:textarea-cursor-word-backward ta)
+    (is (equal '(0 11) (ta-cursor ta)))          ; start of "gamma"
+    (tui.textarea:textarea-cursor-word-backward ta)
+    (is (equal '(0 6) (ta-cursor ta)))           ; start of "beta"
+    (tui.textarea:textarea-cursor-word-backward ta)
+    (is (equal '(0 0) (ta-cursor ta)))))         ; start of "alpha"
+
+(test textarea-key-alt-f-moves-word
+  "Alt+f dispatched through update moves a word forward."
+  (let ((ta (ta-make "alpha beta")))
+    (tui.textarea:textarea-focus ta)
+    (ta-key ta #\f +mod-alt+)
+    (is (equal '(0 6) (ta-cursor ta)))))
+
+;;; --- word deletion ---
+
+(test textarea-delete-word-forward
+  "Alt-d deletes from the cursor to the end of the current word."
+  (let ((ta (ta-make "alpha beta")))
+    (ta-set-cursor ta 0 0)
+    (tui.textarea:textarea-delete-word-forward ta)
+    (is (string= "beta" (tui.textarea:textarea-value ta)))
+    (is (equal '(0 0) (ta-cursor ta)))))
+
+(test textarea-delete-word-backward
+  "Alt-Backspace deletes the word (and trailing space) before the cursor."
+  (let ((ta (ta-make "alpha beta")))
+    (ta-set-cursor ta 0 6)                        ; on "beta"
+    (tui.textarea:textarea-delete-word-backward ta)
+    (is (string= "beta" (tui.textarea:textarea-value ta)))
+    (is (equal '(0 0) (ta-cursor ta)))))
+
+(test textarea-key-ctrl-w-deletes-word
+  "Ctrl+w dispatched through update deletes a word backward."
+  (let ((ta (ta-make "foo bar baz")))
+    (tui.textarea:textarea-focus ta)
+    (ta-set-cursor ta 0 11)                       ; end
+    (ta-key ta #\w +mod-ctrl+)
+    (is (string= "foo bar " (tui.textarea:textarea-value ta)))))
+
+;;; --- transpose & word case (readline niceties) ---
+
+(test textarea-transpose-at-end
+  "Ctrl-T at end of line swaps the last two characters."
+  (let ((ta (ta-make "abc")))
+    (ta-set-cursor ta 0 3)
+    (tui.textarea:textarea-transpose-chars ta)
+    (is (string= "acb" (tui.textarea:textarea-value ta)))))
+
+(test textarea-transpose-mid-advances
+  "Ctrl-T mid-line swaps around the cursor and advances it."
+  (let ((ta (ta-make "abc")))
+    (ta-set-cursor ta 0 1)
+    (tui.textarea:textarea-transpose-chars ta)
+    (is (string= "bac" (tui.textarea:textarea-value ta)))
+    (is (equal '(0 2) (ta-cursor ta)))))
+
+(test textarea-transpose-at-start-noop
+  "Ctrl-T at the start of a line does nothing."
+  (let ((ta (ta-make "abc")))
+    (tui.textarea:textarea-transpose-chars ta)
+    (is (string= "abc" (tui.textarea:textarea-value ta)))))
+
+(test textarea-capitalize-word
+  "Alt-c capitalizes the word at the cursor."
+  (let ((ta (ta-make "hello world")))
+    (tui.textarea:textarea-capitalize-word ta)
+    (is (string= "Hello world" (tui.textarea:textarea-value ta)))
+    (is (equal '(0 5) (ta-cursor ta)))))
+
+(test textarea-uppercase-word
+  "Alt-u uppercases the word at the cursor."
+  (let ((ta (ta-make "hello world")))
+    (tui.textarea:textarea-uppercase-word ta)
+    (is (string= "HELLO world" (tui.textarea:textarea-value ta)))))
+
+(test textarea-lowercase-word
+  "Alt-l lowercases the word at the cursor."
+  (let ((ta (ta-make "HELLO WORLD")))
+    (tui.textarea:textarea-lowercase-word ta)
+    (is (string= "hello WORLD" (tui.textarea:textarea-value ta)))))
+
+(test textarea-key-ctrl-t-transposes
+  "Ctrl+t dispatched through update transposes."
+  (let ((ta (ta-make "abc")))
+    (tui.textarea:textarea-focus ta)
+    (ta-set-cursor ta 0 3)
+    (ta-key ta #\t +mod-ctrl+)
+    (is (string= "acb" (tui.textarea:textarea-value ta)))))
+
+(test textarea-key-alt-u-uppercases
+  "Alt+u dispatched through update uppercases a word."
+  (let ((ta (ta-make "hello")))
+    (tui.textarea:textarea-focus ta)
+    (ta-key ta #\u +mod-alt+)
+    (is (string= "HELLO" (tui.textarea:textarea-value ta)))))
+
+;;; --- char-limit / max-lines enforcement ---
+
+(test textarea-char-limit-trims-insert
+  "char-limit trims inserts and then blocks further input."
+  (let ((ta (tui.textarea:make-textarea :char-limit 5)))
+    (tui.textarea:textarea-insert-string ta "abc")       ; 3 runes
+    (tui.textarea:textarea-insert-string ta "defgh")     ; only 2 more fit
+    (is (= 5 (tui.textarea:textarea-length ta)))
+    (is (string= "abcde" (tui.textarea:textarea-value ta)))
+    (tui.textarea:textarea-insert-string ta "xyz")       ; fully blocked
+    (is (= 5 (tui.textarea:textarea-length ta)))
+    (is (string= "abcde" (tui.textarea:textarea-value ta)))))
+
+(test textarea-max-lines-blocks-newline
+  "max-lines blocks newlines once the line budget is exhausted."
+  (let ((ta (tui.textarea:make-textarea :max-lines 3)))
+    (tui.textarea:textarea-insert-string ta "one")
+    (tui.textarea::textarea-newline ta)
+    (tui.textarea:textarea-insert-string ta "two")
+    (tui.textarea::textarea-newline ta)
+    (tui.textarea:textarea-insert-string ta "three")
+    (is (= 3 (tui.textarea:textarea-line-count ta)))
+    (tui.textarea::textarea-newline ta)                  ; would be a 4th line
+    (is (= 3 (tui.textarea:textarea-line-count ta)))
+    (is (string= (format nil "one~%two~%three")
+                 (tui.textarea:textarea-value ta)))))
+
+(test textarea-max-lines-trims-multiline-paste
+  "A multi-line insert is trimmed to the remaining line budget."
+  (let ((ta (tui.textarea:make-textarea :max-lines 2)))
+    (tui.textarea:textarea-insert-string ta (format nil "a~%b~%c~%d"))
+    (is (= 2 (tui.textarea:textarea-line-count ta)))
+    (is (string= (format nil "a~%b") (tui.textarea:textarea-value ta)))))
+
+(test textarea-paste-inserts-text
+  "A paste message inserts its text."
+  (let ((ta (tui.textarea:make-textarea)))
+    (tui.textarea:textarea-focus ta)
+    (tui.textarea:textarea-update ta (make-paste-msg :text "pasted"))
+    (is (string= "pasted" (tui.textarea:textarea-value ta)))))
+
+;;; --- scroll offset / keep-cursor-in-view (#840) ---
+
+(test textarea-scroll-follows-cursor
+  "ensure-visible advances the offset so the cursor row is on screen."
+  (let ((ta (tui.textarea:make-textarea :height 3 :show-line-numbers nil)))
+    (tui.textarea:textarea-set-value ta (format nil "l0~%l1~%l2~%l3~%l4~%l5"))
+    (is (= 0 (tui.textarea:textarea-scroll-position ta)))
+    (dotimes (i 5) (tui.textarea::textarea-cursor-down ta))
+    (tui.textarea::textarea-ensure-visible ta)
+    (is (= 5 (tui.textarea::textarea-row ta)))
+    (is (= 3 (tui.textarea:textarea-scroll-position ta))))) ; row 5, height 3
+
+(test textarea-scroll-clamps-to-content
+  "The offset never scrolls past the last page of content."
+  (let ((ta (tui.textarea:make-textarea :height 4 :show-line-numbers nil)))
+    (tui.textarea:textarea-set-value ta (format nil "l0~%l1~%l2")) ; 3 lines
+    (ta-set-cursor ta 2 0)
+    (tui.textarea::textarea-ensure-visible ta)
+    (tui.textarea::textarea-clamp-yoffset ta)
+    (is (= 0 (tui.textarea:textarea-scroll-position ta)))))       ; nothing to scroll
+
+(test textarea-scroll-percent
+  "scroll-percent reports progress through the document."
+  (let ((ta (tui.textarea:make-textarea :height 3 :show-line-numbers nil)))
+    (tui.textarea:textarea-set-value ta (format nil "l0~%l1~%l2~%l3~%l4~%l5"))
+    (ta-set-cursor ta 5 0)
+    (tui.textarea::textarea-ensure-visible ta)
+    (is (= 1.0 (tui.textarea:textarea-scroll-percent ta)))
+    (ta-set-cursor ta 0 0)
+    (tui.textarea::textarea-ensure-visible ta)
+    (is (= 0.0 (tui.textarea:textarea-scroll-percent ta)))))
+
+(test textarea-view-renders-scrolled-window
+  "View renders the window around the cursor, not always from line 0."
+  (let ((ta (tui.textarea:make-textarea :height 2 :show-line-numbers nil :prompt "")))
+    (tui.textarea:textarea-set-value ta (format nil "A~%B~%C~%D~%E"))
+    (ta-set-cursor ta 4 0)                          ; row 4 ("E")
+    (let ((out (tui.textarea:textarea-view ta)))
+      (is (search "D" out))
+      (is (search "E" out))
+      (is (not (search "A" out))))))
+
+;;; --- paging (#844) ---
+
+(test textarea-page-down-then-up
+  "Page-down moves by a viewport height and stays visible; page-up reverses."
+  (let ((ta (tui.textarea:make-textarea :height 3 :show-line-numbers nil)))
+    (tui.textarea:textarea-set-value ta
+                                     (format nil "l0~%l1~%l2~%l3~%l4~%l5~%l6"))
+    (tui.textarea:textarea-page-down ta)
+    (is (= 3 (tui.textarea::textarea-row ta)))
+    (tui.textarea::textarea-ensure-visible ta)
+    (is (= 1 (tui.textarea:textarea-scroll-position ta)))
+    (tui.textarea:textarea-page-up ta)
+    (is (= 0 (tui.textarea::textarea-row ta)))))
+
+(test textarea-key-page-down
+  "Page-down dispatched through update advances cursor and offset."
+  (let ((ta (tui.textarea:make-textarea :height 3 :show-line-numbers nil)))
+    (tui.textarea:textarea-set-value ta
+                                     (format nil "l0~%l1~%l2~%l3~%l4~%l5~%l6"))
+    (tui.textarea:textarea-focus ta)
+    (ta-key ta :page-down)
+    (is (= 3 (tui.textarea::textarea-row ta)))
+    (is (= 1 (tui.textarea:textarea-scroll-position ta)))))
+
+;;; --- soft-wrapping ---
+
+(defun ta-wrap (value &rest args)
+  "Make a soft-wrapping textarea (no line numbers, no prompt) with VALUE."
+  (apply #'ta-make value :soft-wrap t :show-line-numbers nil :prompt "" args))
+
+(test textarea-soft-wrap-counts-visual-lines
+  "A line wider than WIDTH occupies multiple visual lines."
+  (let ((ta (tui.textarea:make-textarea :width 5 :height 10 :soft-wrap t
+                                        :show-line-numbers nil :prompt "")))
+    (tui.textarea:textarea-set-value ta "abcdefghij")     ; 10 chars at width 5
+    (is (= 2 (tui.textarea:textarea-visual-line-count ta)))))
+
+(test textarea-soft-wrap-empty-line
+  "An empty line still counts as one visual line."
+  (let ((ta (tui.textarea:make-textarea :width 5 :height 10 :soft-wrap t
+                                        :show-line-numbers nil :prompt "")))
+    (tui.textarea:textarea-set-value ta "")
+    (is (= 1 (tui.textarea:textarea-visual-line-count ta)))))
+
+(test textarea-no-wrap-counts-logical-lines
+  "Without soft-wrap, visual-line-count equals the logical line count."
+  (let ((ta (tui.textarea:make-textarea :width 5 :height 10
+                                        :show-line-numbers nil :prompt "")))
+    (tui.textarea:textarea-set-value ta "abcdefghij")
+    (is (= 1 (tui.textarea:textarea-visual-line-count ta)))))
+
+(test textarea-soft-wrap-renders-segments
+  "View renders a long line as consecutive width-bounded segments."
+  (let ((ta (tui.textarea:make-textarea :width 5 :height 5 :soft-wrap t
+                                        :show-line-numbers nil :prompt "")))
+    (tui.textarea:textarea-set-value ta "abcdefghij")
+    (let ((out (tui.textarea:textarea-view ta)))
+      (is (search "abcde" out))
+      (is (search "fghij" out)))))
+
+(test textarea-soft-wrap-cursor-on-segment
+  "The cursor highlight lands on the wrapped segment that contains it."
+  (let ((ta (tui.textarea:make-textarea :width 5 :height 5 :soft-wrap t
+                                        :show-line-numbers nil :prompt "")))
+    (tui.textarea:textarea-set-value ta "abcdefghij")
+    (tui.textarea:textarea-focus ta)
+    (ta-set-cursor ta 0 7)                                ; on 'h', in 2nd segment
+    (let ((out (tui.textarea:textarea-view ta)))
+      (is (search "abcde" out))
+      (is (search "fg[h]ij" out)))))
+
+(test textarea-soft-wrap-scroll-follows-cursor
+  "Scrolling tracks the cursor in visual lines when soft-wrapping."
+  (let ((ta (tui.textarea:make-textarea :width 5 :height 3 :soft-wrap t
+                                        :show-line-numbers nil :prompt "")))
+    ;; 4 logical lines of 10 chars each -> 8 visual lines at width 5.
+    (tui.textarea:textarea-set-value ta
+                                     (format nil "aaaaaaaaaa~%bbbbbbbbbb~%cccccccccc~%dddddddddd"))
+    (ta-set-cursor ta 3 0)                                ; first segment of row 3 -> vi 6
+    (tui.textarea::textarea-ensure-visible ta)
+    (is (= 4 (tui.textarea:textarea-scroll-position ta)))))
+
+(test textarea-soft-wrap-scroll-percent
+  "scroll-percent reaches 1.0 at the bottom of wrapped content."
+  (let ((ta (tui.textarea:make-textarea :width 5 :height 3 :soft-wrap t
+                                        :show-line-numbers nil :prompt "")))
+    (tui.textarea:textarea-set-value ta
+                                     (format nil "aaaaaaaaaa~%bbbbbbbbbb~%cccccccccc~%dddddddddd"))
+    (ta-set-cursor ta 3 10)                               ; very end -> last visual line
+    (tui.textarea::textarea-ensure-visible ta)
+    (is (= 1.0 (tui.textarea:textarea-scroll-percent ta)))))
+
+;;; --- dynamic height (#910) ---
+
+(test textarea-dynamic-height-grows-to-content
+  "Dynamic height grows the viewport to fit the content."
+  (let ((ta (tui.textarea:make-textarea :dynamic-height t :min-height 1 :max-height 0
+                                        :show-line-numbers nil :prompt "")))
+    (tui.textarea:textarea-set-value ta (format nil "a~%b~%c"))
+    (tui.textarea:textarea-recalculate-height ta)
+    (is (= 3 (tui.textarea:textarea-height ta)))))
+
+(test textarea-dynamic-height-respects-min
+  "Dynamic height never drops below min-height."
+  (let ((ta (tui.textarea:make-textarea :dynamic-height t :min-height 4 :max-height 0
+                                        :show-line-numbers nil :prompt "")))
+    (tui.textarea:textarea-set-value ta "a")
+    (tui.textarea:textarea-recalculate-height ta)
+    (is (= 4 (tui.textarea:textarea-height ta)))))
+
+(test textarea-dynamic-height-respects-max
+  "Dynamic height is capped at max-height."
+  (let ((ta (tui.textarea:make-textarea :dynamic-height t :min-height 1 :max-height 5
+                                        :show-line-numbers nil :prompt "")))
+    (tui.textarea:textarea-set-value ta (format nil "1~%2~%3~%4~%5~%6~%7~%8~%9~%10"))
+    (tui.textarea:textarea-recalculate-height ta)
+    (is (= 5 (tui.textarea:textarea-height ta)))))
+
+(test textarea-dynamic-height-counts-visual-lines
+  "Dynamic height counts visual lines when soft-wrap is on."
+  (let ((ta (tui.textarea:make-textarea :width 5 :dynamic-height t :min-height 1 :max-height 0
+                                        :soft-wrap t :show-line-numbers nil :prompt "")))
+    (tui.textarea:textarea-set-value ta "abcdefghij")     ; 2 visual lines at width 5
+    (tui.textarea:textarea-recalculate-height ta)
+    (is (= 2 (tui.textarea:textarea-height ta)))))
+
+(test textarea-dynamic-height-on-update
+  "Typing a newline recalculates the viewport height through update."
+  (let ((ta (tui.textarea:make-textarea :dynamic-height t :min-height 1 :max-height 0
+                                        :show-line-numbers nil :prompt "")))
+    (tui.textarea:textarea-focus ta)
+    (ta-key ta :enter)                                   ; empty -> 2 lines
+    (is (= 2 (tui.textarea:textarea-height ta)))))
+
+;;; --- regression: pre-existing behaviour still works ---
+
+(test textarea-backspace-merges-lines
+  "Backspace at the start of a line merges it with the previous line."
+  (let ((ta (ta-make (format nil "ab~%cd"))))
+    (ta-set-cursor ta 1 0)
+    (tui.textarea::textarea-delete-char-backward ta)
+    (is (= 1 (tui.textarea:textarea-line-count ta)))
+    (is (string= "abcd" (tui.textarea:textarea-value ta)))))
+
+(test textarea-ignores-input-when-blurred
+  "A blurred textarea ignores key messages."
+  (let ((ta (ta-make "abc")))
+    (ta-key ta :backspace)
+    (is (string= "abc" (tui.textarea:textarea-value ta)))))

--- a/tuition.asd
+++ b/tuition.asd
@@ -67,6 +67,7 @@
                              (:file "test-table")
                              (:file "test-tree")
                              (:file "test-input")
-                             (:file "test-text"))))
+                             (:file "test-text")
+                             (:file "test-textarea"))))
   :perform (test-op (o c)
                     (symbol-call :tuition-tests :run-tests)))


### PR DESCRIPTION
Ports a batch of recent `charmbracelet/bubbles` textarea features to tuition's textarea, and fixes one latent crash along the way. Soft-wrap and dynamic-height are **opt-in**, so existing behaviour is unchanged.

## What's new

**Scrolling & cursor visibility**
- Vertical scroll offset with keep-cursor-in-view — the cursor no longer walks off-screen once content exceeds the viewport (previously `textarea-view` always rendered from line 0).
- `page-up` / `page-down` and `scroll-position` / `scroll-percent` accessors.

**Editing / readline set**
- Document-level `move-to-begin` / `move-to-end`.
- `word` (word under the cursor), word navigation (`Alt-b` / `Alt-f`), word deletion (`Ctrl-w`, `Alt-Backspace`, `Alt-d`).
- `transpose-chars` (`Ctrl-T`) and word-case commands (`Alt-c` / `Alt-l` / `Alt-u`).
- Bracketed-paste support.

**Limits**
- `char-limit` and `max-lines` are now actually enforced on insert (the slots existed but were never checked).

**Soft-wrapping** — `(make-textarea :soft-wrap t …)`
- Long lines wrap to `width` **display columns**, measured with `visible-length` so wide/combining chars (CJK, emoji) are handled.
- Character wrapping (greedy) — the safe default for a text input; long tokens/URLs never overflow. Cursor, scroll offset, and page tracking all move to **visual** lines; the `[c]` highlight lands on the correct wrapped segment.

**Dynamic height** (#910) — `(make-textarea :dynamic-height t …)`
- Viewport grows/shrinks to fit content, clamped between `:min-height` and `:max-height` (0 = uncapped). Counts visual lines, so it composes correctly with soft-wrap.

## Bug fix

`textarea-set-value` built a plain `(coerce … 'vector)`, but the delete-merge paths call `adjust-array … :fill-pointer`, which only works on an adjustable vector with a fill-pointer. So **backspace after `set-value` always crashed**. Fixed to build the same adjustable fill-pointer vector the rest of the code expects.

## Tests

New `tests/test-textarea.lisp` (FiveAm). Full suite: **306/306 passing**. Clean SBCL compile (no warnings); `chat` and `textinput-component` examples compile against the expanded API.

## Notes / follow-ups
- Soft-wrap is character wrapping; a `:word-wrap` option could be added later.
- `page-up`/`page-down` still move by logical rows in wrap mode (approximation); the viewport scrolls visually and the cursor stays in view regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)