### PR TITLE
ci: explicitly install parse-declarations-1.0 for serapeum subsystems

### DIFF
--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -35,7 +35,10 @@ jobs:
 
       - name: Fetch Lisp dependencies
         run: |
-          ocicl install bordeaux-threads trivial-channels version-string alexandria serapeum cl-base64 fiveam
+          # parse-declarations-1.0 is required by serapeum's subsystems
+          # (serapeum/macro-tools, serapeum/iter); ocicl only resolves the
+          # main system's :depends-on, so it must be listed explicitly.
+          ocicl install bordeaux-threads trivial-channels version-string alexandria serapeum cl-base64 fiveam parse-declarations-1.0
 
       - name: Upload ocicl directory
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4


### PR DESCRIPTION
Fixes the failing `test` CI job.

## Root cause

Every `test` job (ubuntu/macos/windows) failed with:

```
Component "parse-declarations-1.0" not found, required by #<SYSTEM "serapeum/macro-tools">
```

`ocicl install <system>` resolves only the named system's **main** `:depends-on` — it does not recurse into subsystem definitions. `serapeum.asd` defines subsystems (`serapeum/macro-tools`, `serapeum/iter`) whose `:depends-on` includes `parse-declarations-1.0`, so it was never fetched. ASDF needs it when loading serapeum (a tuition dependency).

`fetch-deps` passed because it only runs the install; the failure surfaced in the `test` job when loading `:tuition`.

## Fix

Add `parse-declarations-1.0` to the explicit `ocicl install` line in `fetch-deps`, with a comment explaining why.

## Validation

Reproduced the fetch set locally (`ocicl install bordeaux-threads trivial-channels version-string alexandria serapeum cl-base64 fiveam parse-declarations-1.0`), then loaded `:tuition` and `:tuition/tests` against **only** that set — **344/344 checks pass**.

## Note

This keeps the existing "library" model (no committed `ocicl.csv` lockfile), so it's a targeted fix. The flip side is that if serapeum adds another subsystem-only dependency in future, CI would break again — at which point committing an `ocicl.csv` and switching to a no-arg `ocicl install` would be the more durable option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)