### PR TITLE
ci: force LF checkout and fix Ubuntu install step

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Normalize all text files to LF on checkout regardless of platform.
+# Without this, GitHub Actions' default core.autocrlf on Windows converts
+# sources and golden fixtures to CRLF, which (a) breaks FORMAT directives
+# that rely on ~<newline> continuation in tests/golden.lisp and (b) makes
+# golden fixtures mismatch LF-rendered output.
+* text=auto eol=lf

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -81,15 +81,15 @@ jobs:
 
       - name: Install deps (Linux)
         if: runner.os == 'Linux'
-        env:
-          INSTALL_CMD: ${{ matrix.deps }}
-        run: $INSTALL_CMD
+        # Use ${{ matrix.deps }} directly (not via an env var) so the shell
+        # re-parses operators like &&; `run: $INSTALL_CMD` would pass them as
+        # literal arguments (e.g. "apt-get update && ..." -> "update" gets
+        # "&&" as an arg -> "The update command takes no arguments").
+        run: ${{ matrix.deps }}
 
       - name: Install deps (macOS)
         if: runner.os == 'macOS'
-        env:
-          INSTALL_CMD: ${{ matrix.deps }}
-        run: $INSTALL_CMD
+        run: ${{ matrix.deps }}
 
       - name: Install deps (Windows)
         if: runner.os == 'Windows'


### PR DESCRIPTION
Follow-up to #23 to get the remaining CI jobs green. macOS already passes after the `parse-declarations-1.0` fix; this addresses the other two platforms.

## Windows — CRLF on checkout

GitHub Actions' default `core.autocrlf` converts sources and golden fixtures to CRLF on the Windows runner. This breaks two things:

1. `tests/golden.lisp` uses `~<newline>` format continuation. Under CRLF the `~` is followed by `\r`, which is an invalid directive → `SB-FORMAT:FORMAT-ERROR` (only reached when a golden test mismatches).
2. Golden fixtures get CRLF, so they mismatch the LF-rendered output.

**Fix:** add `.gitattributes` with `* text=auto eol=lf` to force LF on all platforms.

## Ubuntu — install step

`run: $INSTALL_CMD` (bash variable expansion) does not re-parse shell operators, so the matrix value `sudo apt-get update && sudo apt-get install -y sbcl` passed `&& ...` as arguments to `apt-get update` → `The update command takes no arguments` (exit 100). SBCL never installed.

**Fix:** use `${{ matrix.deps }}` directly in `run:` so GitHub substitutes the command into the script and bash parses `&&` (macOS already worked because its command has no operator).

## Note
Both are pre-existing issues (independent of the 2.2.0 feature work); they were masked because every job was already failing earlier at the `parse-declarations-1.0` load error fixed in #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)